### PR TITLE
createHeaderValue options.data may be a Blob, so digest can be created for non-JSON without serializing as String

### DIFF
--- a/lib/httpDigest.js
+++ b/lib/httpDigest.js
@@ -9,7 +9,7 @@ import crypto from './crypto.js';
  * Creates a value suitable for the HTTP `Digest` header.
  *
  * @param {object} options - The options to use.
- * @param {string|object} options.data - Objects to be hashed
+ * @param {string|object|Blob} options.data - Objects to be hashed
  *   (typically headers).
  * @param {string} [options.algorithm] - Hash algorithm to use.
  *   (e.g. 'sha256').
@@ -20,9 +20,22 @@ import crypto from './crypto.js';
  */
 export async function createHeaderValue(
   {data, algorithm = 'sha256', useMultihash = true} = {}) {
+  const body = _createDataBlob(data)
   const {key, encodedDigest} = await _createHeaderValueComponents(
-    {data, algorithm, useMultihash});
+    {body, algorithm, useMultihash});
   return `${key}=${encodedDigest}`;
+}
+
+/**
+ * some of functions in this module accept several types for 'data'.
+ * this normalizes any/all of those to a Blob, which is like data but also carries a .type.
+ * @param {stringobject|Blob} data - if string, will be assumed to be JSON (for back compat)
+ * @returns {Blob}
+ */
+function _createDataBlob(data) {
+  if (data instanceof Blob) return data
+  if (typeof data === 'string') return new Blob([data],{type:'application/json'})
+  return new Blob([JSON.stringify(data)],{type:'application/json'})
 }
 
 /**
@@ -39,22 +52,26 @@ export async function createHeaderValue(
 export async function verifyHeaderValue({data, headerValue} = {}) {
   try {
     const {key, algorithm, encodedDigest} = _parseHeaderValue(headerValue);
+    const body = _createDataBlob(data)
     const {encodedDigest: expectedDigest} = await _createHeaderValueComponents(
-      {data, algorithm, useMultihash: key === 'mh'});
+      {body, algorithm, useMultihash: key === 'mh'});
     return {verified: encodedDigest === expectedDigest};
   } catch(error) {
     return {verified: false, error};
   }
 }
 
+/**
+ * @param {object} options
+ * @param {Blob} options.body - request body
+ * @param {boolean} options.useMultihash - whether to serialize digest using multihash or not
+ */
 async function _createHeaderValueComponents(
-  {data, algorithm = 'sha256', useMultihash = true} = {}) {
-  if(typeof data !== 'string') {
-    data = JSON.stringify(data);
-  }
+  {body, algorithm = 'sha256', useMultihash = true} = {}) {
   if(algorithm !== 'sha256') {
     throw new Error(`Algorithm "${algorithm}" is not supported.`);
   }
+  const data = await body.bytes()
   const digest = await _getDigest({data, algorithm});
   if(useMultihash) {
     return {key: 'mh', encodedDigest: _createMultihash({digest})};
@@ -84,11 +101,17 @@ function _parseHeaderValue(headerValue) {
   return {key, algorithm, encodedDigest};
 }
 
+/**
+ * @param options
+ * @param {Uint8Array} options.data - data to get digest of
+ * @param {'sha256'} options.algorithm - algorithm to use to digest
+ * @returns 
+ */
 async function _getDigest({data, algorithm}) {
-  const encodedData = new TextEncoder().encode(data);
+  if (!(data instanceof Uint8Array)) throw new Error(`_getDigest options.data MUST be Uint8Array`)
   if(algorithm === 'sha256') {
     return new Uint8Array(
-      await crypto.subtle.digest({name: 'SHA-256'}, encodedData));
+      await crypto.subtle.digest({name: 'SHA-256'}, data));
   }
   throw new Error(`Algorithm "${algorithm}" is not unsupported.`);
 }

--- a/lib/httpDigest.js
+++ b/lib/httpDigest.js
@@ -102,13 +102,12 @@ function _parseHeaderValue(headerValue) {
 }
 
 /**
- * @param options
+ * @param {object} options
  * @param {Uint8Array} options.data - data to get digest of
  * @param {'sha256'} options.algorithm - algorithm to use to digest
  * @returns 
  */
 async function _getDigest({data, algorithm}) {
-  if (!(data instanceof Uint8Array)) throw new Error(`_getDigest options.data MUST be Uint8Array`)
   if(algorithm === 'sha256') {
     return new Uint8Array(
       await crypto.subtle.digest({name: 'SHA-256'}, data));

--- a/test/unit/httpDigest.spec.js
+++ b/test/unit/httpDigest.spec.js
@@ -172,41 +172,40 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(false);
     });
     it('should verify false if hashedDigestStringValue and headerValue ' +
-      'are not equal when header is multihash', async () => {
-        const data = `{"hello": "world"}`;
-        const headerValue = await createHeaderValue(
-          { data, useMultihash: true }
-        );
-        const dataToVerify = `{"hello": "earth"}`;
-        let verifyResult;
-        let err;
-        try {
-          verifyResult = await verifyHeaderValue({
-            data: dataToVerify, headerValue
-          });
-        } catch (e) {
-          err = e;
-        }
-        should.not.exist(err);
-        should.exist(verifyResult);
-        verifyResult.verified.should.equal(false);
-      });
+     'are not equal when header is multihash', async () => {
+      const data = `{"hello": "world"}`;
+      const headerValue = await createHeaderValue(
+        {data, useMultihash: true}
+      );
+      const dataToVerify = `{"hello": "earth"}`;
+      let verifyResult;
+      let err;
+      try {
+        verifyResult = await verifyHeaderValue({
+          data: dataToVerify, headerValue});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(verifyResult);
+      verifyResult.verified.should.equal(false);
+    });
     it('should verify true if hashedDigestStringValue and headerValue ' +
       'are equal when header is multihash', async () => {
-        const data = `{"hello": "world"}`;
-        const headerValue = await createHeaderValue(
-          { data, useMultihash: true }
-        );
-        let verifyResult;
-        let err;
-        try {
-          verifyResult = await verifyHeaderValue({ data, headerValue });
-        } catch (e) {
-          err = e;
-        }
-        should.not.exist(err);
-        should.exist(verifyResult);
-        verifyResult.verified.should.equal(true);
-      });
+      const data = `{"hello": "world"}`;
+      const headerValue = await createHeaderValue(
+        {data, useMultihash: true}
+      );
+      let verifyResult;
+      let err;
+      try {
+        verifyResult = await verifyHeaderValue({data, headerValue});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(verifyResult);
+      verifyResult.verified.should.equal(true);
+    });
   });
 });

--- a/test/unit/httpDigest.spec.js
+++ b/test/unit/httpDigest.spec.js
@@ -11,9 +11,9 @@ describe('http-signature-digest', () => {
       let err;
       try {
         result = await createHeaderValue(
-          { data, algorithm: 'sha256', useMultihash: false }
+          {data, algorithm: 'sha256', useMultihash: false}
         );
-      } catch (e) {
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);
@@ -27,8 +27,8 @@ describe('http-signature-digest', () => {
         let result;
         let err;
         try {
-          result = await createHeaderValue({ data, useMultihash: true });
-        } catch (e) {
+          result = await createHeaderValue({data, useMultihash: true});
+        } catch(e) {
           err = e;
         }
         should.not.exist(err);
@@ -38,9 +38,9 @@ describe('http-signature-digest', () => {
       });
 
     it('should create a digest of an object', async () => {
-      const data = { hello: 'world' };
+      const data = {hello: 'world'};
       const objDigest = await createHeaderValue(
-        { data, algorithm: 'sha256', useMultihash: false }
+        {data, algorithm: 'sha256', useMultihash: false}
       );
       let stringDigest;
       let err;
@@ -50,7 +50,7 @@ describe('http-signature-digest', () => {
           algorithm: 'sha256',
           useMultihash: false
         });
-      } catch (e) {
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);
@@ -82,15 +82,15 @@ describe('http-signature-digest', () => {
 
     it('should create a digest of an object with useMultihash set to true',
       async () => {
-        const data = { hello: 'world' };
-        const headerValue = await createHeaderValue({ data, useMultihash: true });
+        const data = {hello: 'world'};
+        const headerValue = await createHeaderValue({data, useMultihash: true});
         let stringHeaderValue;
         let err;
         try {
           stringHeaderValue = await createHeaderValue(
-            { data: '{"hello":"world"}', useMultihash: true }
+            {data: '{"hello":"world"}', useMultihash: true}
           );
-        } catch (e) {
+        } catch(e) {
           err = e;
         }
         should.not.exist(err);
@@ -104,13 +104,13 @@ describe('http-signature-digest', () => {
     it('should verify a digest of a given string', async () => {
       const data = `{"hello": "world"}`;
       const headerValue = await createHeaderValue(
-        { data, algorithm: 'sha256', useMultihash: false }
+        {data, algorithm: 'sha256', useMultihash: false}
       );
       let verifyResult;
       let err;
       try {
-        verifyResult = await verifyHeaderValue({ data, headerValue });
-      } catch (e) {
+        verifyResult = await verifyHeaderValue({data, headerValue});
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);
@@ -118,15 +118,15 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(true);
     });
     it('should verify a digest of a given object', async () => {
-      const data = { hello: 'world' };
+      const data = {hello: 'world'};
       const headerValue = await createHeaderValue(
-        { data, algorithm: 'sha256', useMultihash: false }
+        {data, algorithm: 'sha256', useMultihash: false}
       );
       let verifyResult;
       let err;
       try {
-        verifyResult = await verifyHeaderValue({ data, headerValue });
-      } catch (e) {
+        verifyResult = await verifyHeaderValue({data, headerValue});
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);
@@ -134,18 +134,17 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(true);
     });
     it('should verify false if verifying bad data object', async () => {
-      const data = { hello: 'world' };
+      const data = {hello: 'world'};
       const headerValue = await createHeaderValue(
-        { data, algorithm: 'sha256', useMultihash: false }
+        {data, algorithm: 'sha256', useMultihash: false}
       );
-      const dataToVerify = { hello: 'earth' };
+      const dataToVerify = {hello: 'earth'};
       let verifyResult;
       let err;
       try {
         verifyResult = await verifyHeaderValue({
-          data: dataToVerify, headerValue
-        });
-      } catch (e) {
+          data: dataToVerify, headerValue});
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);
@@ -155,16 +154,15 @@ describe('http-signature-digest', () => {
     it('should verify false if verifying bad data string', async () => {
       const data = `{"hello": "world"}`;
       const headerValue = await createHeaderValue(
-        { data, algorithm: 'sha256', useMultihash: false }
+        {data, algorithm: 'sha256', useMultihash: false}
       );
       const dataToVerify = `{"hello": "earth"}`;
       let verifyResult;
       let err;
       try {
         verifyResult = await verifyHeaderValue({
-          data: dataToVerify, headerValue
-        });
-      } catch (e) {
+          data: dataToVerify, headerValue});
+      } catch(e) {
         err = e;
       }
       should.not.exist(err);

--- a/test/unit/httpDigest.spec.js
+++ b/test/unit/httpDigest.spec.js
@@ -11,9 +11,9 @@ describe('http-signature-digest', () => {
       let err;
       try {
         result = await createHeaderValue(
-          {data, algorithm: 'sha256', useMultihash: false}
+          { data, algorithm: 'sha256', useMultihash: false }
         );
-      } catch(e) {
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -27,8 +27,8 @@ describe('http-signature-digest', () => {
         let result;
         let err;
         try {
-          result = await createHeaderValue({data, useMultihash: true});
-        } catch(e) {
+          result = await createHeaderValue({ data, useMultihash: true });
+        } catch (e) {
           err = e;
         }
         should.not.exist(err);
@@ -38,9 +38,9 @@ describe('http-signature-digest', () => {
       });
 
     it('should create a digest of an object', async () => {
-      const data = {hello: 'world'};
+      const data = { hello: 'world' };
       const objDigest = await createHeaderValue(
-        {data, algorithm: 'sha256', useMultihash: false}
+        { data, algorithm: 'sha256', useMultihash: false }
       );
       let stringDigest;
       let err;
@@ -50,7 +50,7 @@ describe('http-signature-digest', () => {
           algorithm: 'sha256',
           useMultihash: false
         });
-      } catch(e) {
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -60,17 +60,37 @@ describe('http-signature-digest', () => {
         .equal('SHA-256=k6I5cakU5erL8KjSUVTNownDwccvu5kU1Hxg88toFYg=');
     });
 
+    it('should create a digest of a JSON blob', async () => {
+      const object = { hello: 'world' };
+      const data = new Blob([JSON.stringify(object)], { type: 'application/json' })
+      const objDigest = await createHeaderValue(
+        { data, algorithm: 'sha256', useMultihash: false }
+      );
+      objDigest.should
+        .equal('SHA-256=k6I5cakU5erL8KjSUVTNownDwccvu5kU1Hxg88toFYg=');
+    });
+
+    it('should create a digest of a text/plain blob', async () => {
+      const object = { hello: 'world' };
+      const data = new Blob([JSON.stringify(object)], { type: 'text/plain' })
+      const objDigest = await createHeaderValue(
+        { data, algorithm: 'sha256', useMultihash: false }
+      );
+      objDigest.should
+        .equal('SHA-256=k6I5cakU5erL8KjSUVTNownDwccvu5kU1Hxg88toFYg=');
+    });
+
     it('should create a digest of an object with useMultihash set to true',
       async () => {
-        const data = {hello: 'world'};
-        const headerValue = await createHeaderValue({data, useMultihash: true});
+        const data = { hello: 'world' };
+        const headerValue = await createHeaderValue({ data, useMultihash: true });
         let stringHeaderValue;
         let err;
         try {
           stringHeaderValue = await createHeaderValue(
-            {data: '{"hello":"world"}', useMultihash: true}
+            { data: '{"hello":"world"}', useMultihash: true }
           );
-        } catch(e) {
+        } catch (e) {
           err = e;
         }
         should.not.exist(err);
@@ -84,13 +104,13 @@ describe('http-signature-digest', () => {
     it('should verify a digest of a given string', async () => {
       const data = `{"hello": "world"}`;
       const headerValue = await createHeaderValue(
-        {data, algorithm: 'sha256', useMultihash: false}
+        { data, algorithm: 'sha256', useMultihash: false }
       );
       let verifyResult;
       let err;
       try {
-        verifyResult = await verifyHeaderValue({data, headerValue});
-      } catch(e) {
+        verifyResult = await verifyHeaderValue({ data, headerValue });
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -98,15 +118,15 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(true);
     });
     it('should verify a digest of a given object', async () => {
-      const data = {hello: 'world'};
+      const data = { hello: 'world' };
       const headerValue = await createHeaderValue(
-        {data, algorithm: 'sha256', useMultihash: false}
+        { data, algorithm: 'sha256', useMultihash: false }
       );
       let verifyResult;
       let err;
       try {
-        verifyResult = await verifyHeaderValue({data, headerValue});
-      } catch(e) {
+        verifyResult = await verifyHeaderValue({ data, headerValue });
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -114,17 +134,18 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(true);
     });
     it('should verify false if verifying bad data object', async () => {
-      const data = {hello: 'world'};
+      const data = { hello: 'world' };
       const headerValue = await createHeaderValue(
-        {data, algorithm: 'sha256', useMultihash: false}
+        { data, algorithm: 'sha256', useMultihash: false }
       );
-      const dataToVerify = {hello: 'earth'};
+      const dataToVerify = { hello: 'earth' };
       let verifyResult;
       let err;
       try {
         verifyResult = await verifyHeaderValue({
-          data: dataToVerify, headerValue});
-      } catch(e) {
+          data: dataToVerify, headerValue
+        });
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -134,15 +155,16 @@ describe('http-signature-digest', () => {
     it('should verify false if verifying bad data string', async () => {
       const data = `{"hello": "world"}`;
       const headerValue = await createHeaderValue(
-        {data, algorithm: 'sha256', useMultihash: false}
+        { data, algorithm: 'sha256', useMultihash: false }
       );
       const dataToVerify = `{"hello": "earth"}`;
       let verifyResult;
       let err;
       try {
         verifyResult = await verifyHeaderValue({
-          data: dataToVerify, headerValue});
-      } catch(e) {
+          data: dataToVerify, headerValue
+        });
+      } catch (e) {
         err = e;
       }
       should.not.exist(err);
@@ -150,40 +172,41 @@ describe('http-signature-digest', () => {
       verifyResult.verified.should.equal(false);
     });
     it('should verify false if hashedDigestStringValue and headerValue ' +
-     'are not equal when header is multihash', async () => {
-      const data = `{"hello": "world"}`;
-      const headerValue = await createHeaderValue(
-        {data, useMultihash: true}
-      );
-      const dataToVerify = `{"hello": "earth"}`;
-      let verifyResult;
-      let err;
-      try {
-        verifyResult = await verifyHeaderValue({
-          data: dataToVerify, headerValue});
-      } catch(e) {
-        err = e;
-      }
-      should.not.exist(err);
-      should.exist(verifyResult);
-      verifyResult.verified.should.equal(false);
-    });
+      'are not equal when header is multihash', async () => {
+        const data = `{"hello": "world"}`;
+        const headerValue = await createHeaderValue(
+          { data, useMultihash: true }
+        );
+        const dataToVerify = `{"hello": "earth"}`;
+        let verifyResult;
+        let err;
+        try {
+          verifyResult = await verifyHeaderValue({
+            data: dataToVerify, headerValue
+          });
+        } catch (e) {
+          err = e;
+        }
+        should.not.exist(err);
+        should.exist(verifyResult);
+        verifyResult.verified.should.equal(false);
+      });
     it('should verify true if hashedDigestStringValue and headerValue ' +
       'are equal when header is multihash', async () => {
-      const data = `{"hello": "world"}`;
-      const headerValue = await createHeaderValue(
-        {data, useMultihash: true}
-      );
-      let verifyResult;
-      let err;
-      try {
-        verifyResult = await verifyHeaderValue({data, headerValue});
-      } catch(e) {
-        err = e;
-      }
-      should.not.exist(err);
-      should.exist(verifyResult);
-      verifyResult.verified.should.equal(true);
-    });
+        const data = `{"hello": "world"}`;
+        const headerValue = await createHeaderValue(
+          { data, useMultihash: true }
+        );
+        let verifyResult;
+        let err;
+        try {
+          verifyResult = await verifyHeaderValue({ data, headerValue });
+        } catch (e) {
+          err = e;
+        }
+        should.not.exist(err);
+        should.exist(verifyResult);
+        verifyResult.verified.should.equal(true);
+      });
   });
 });


### PR DESCRIPTION
Motivation:
* I'm modifying https://github.com/gobengo/http-signature-zcap-invoke to be able to better handle invoking requests whose http request body is not JSON, but instead any other media type.
* it calls this library to make the digest, but this library only makes digest for json
* this PR allows making digest for any Blob, aka any bytes.
* i believe it is backward compatible with the previous interface, but now accepts options.data as Blob
* i could have made options.data accept ArrayBuffer or something, but Blob felt appropriate because it's possible this logic might want to vary depending on the content-type of the data (even though it doesn't right now).