### PR TITLE
Support base64-encoded digest bytes wrapped in colons

### DIFF
--- a/lib/httpDigest.js
+++ b/lib/httpDigest.js
@@ -63,7 +63,10 @@ async function _createHeaderValueComponents(
 }
 
 function _parseHeaderValue(headerValue) {
-  const [key, encodedDigest] = headerValue.split(/=(.+)/);
+  const [key, digest] = headerValue.split(/=(.+)/);
+
+  // Unwrap in case the base64-encoded digest bytes are wrapped in colons
+  const encodedDigest = digest?.replace(/^:(.*):$/, '$1');
 
   let algorithm;
   if(key === 'mh') {

--- a/test/unit/httpDigest.spec.js
+++ b/test/unit/httpDigest.spec.js
@@ -113,6 +113,21 @@ describe('http-signature-digest', () => {
       should.exist(verifyResult);
       verifyResult.verified.should.equal(true);
     });
+    it('should verify a digest wrapped in colons', async () => {
+      const data = `{"hello": "world"}`;
+      const headerValue =
+        `sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:`;
+      let verifyResult;
+      let err;
+      try {
+        verifyResult = await verifyHeaderValue({data, headerValue});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(verifyResult);
+      verifyResult.verified.should.equal(true);
+    });
     it('should verify false if verifying bad data object', async () => {
       const data = {hello: 'world'};
       const headerValue = await createHeaderValue(


### PR DESCRIPTION
The latest Digest Fields RFC 9530 specifies base64-encoded digest bytes wrapped in colons. See:
https://datatracker.ietf.org/doc/html/rfc9530#section-2

This PR does not change of the behavior of `createDigestString`, just extends `verifyDigestString` so it also accepts and unwraps digest bytes wrapped in colons